### PR TITLE
Add the thanos dep replace back in

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,3 +84,6 @@ exclude (
 	k8s.io/client-go v9.0.0+incompatible
 	k8s.io/client-go v9.0.0-invalid+incompatible
 )
+
+// Replacing this cuts that dependency branch by making an older cortex version depend on on a newer thanos
+replace github.com/thanos-io/thanos v0.13.1-0.20210108102609-f85e4003ba51 => github.com/thanos-io/thanos v0.13.1-0.20210122144644-4b4994212b24


### PR DESCRIPTION
Accidentally removed this in https://github.com/grafana/influx2cortex/pull/4.

Without this line, the following spiral happens during a docker build:
```
#14 11.52 go: github.com/cortexproject/cortex@v1.11.0 requires
#14 11.52 	github.com/thanos-io/thanos@v0.22.0 requires
#14 11.52 	github.com/cortexproject/cortex@v1.8.1-0.20210422151339-cf1c444e0905 requires
#14 11.52 	github.com/thanos-io/thanos@v0.13.1-0.20210401085038-d7dff0c84d17 requires
#14 11.52 	github.com/cortexproject/cortex@v1.7.1-0.20210316085356-3fedc1108a49 requires
#14 11.52 	github.com/thanos-io/thanos@v0.13.1-0.20210226164558-03dace0a1aa1 requires
#14 11.52 	github.com/cortexproject/cortex@v1.7.1-0.20210224085859-66d6fb5b0d42 requires
#14 11.52 	github.com/thanos-io/thanos@v0.13.1-0.20210224074000-659446cab117 requires
#14 11.52 	github.com/cortexproject/cortex@v1.6.1-0.20210215155036-dfededd9f331 requires
#14 11.52 	github.com/thanos-io/thanos@v0.13.1-0.20210204123931-82545cdd16fe requires
#14 11.52 	github.com/cortexproject/cortex@v1.6.1-0.20210108144208-6c2dab103f20 requires
#14 11.52 	github.com/thanos-io/thanos@v0.13.1-0.20210108102609-f85e4003ba51 requires
#14 11.52 	github.com/cortexproject/cortex@v1.5.1-0.20201111110551-ba512881b076 requires
#14 11.52 	github.com/thanos-io/thanos@v0.13.1-0.20201030101306-47f9a225cc52 requires
#14 11.52 	github.com/cortexproject/cortex@v1.4.1-0.20201030080541-83ad6df2abea requires
#14 11.52 	github.com/thanos-io/thanos@v0.13.1-0.20201019130456-f41940581d9a requires
#14 11.52 	github.com/cortexproject/cortex@v1.3.1-0.20200923145333-8587ea61fe17 requires
#14 11.52 	github.com/thanos-io/thanos@v0.13.1-0.20200807203500-9b578afb4763 requires
#14 11.52 	github.com/cortexproject/cortex@v1.2.1-0.20200805064754-d8edc95e2c91 requires
#14 11.52 	github.com/thanos-io/thanos@v0.13.1-0.20200731083140-69b87607decf requires
#14 11.52 	github.com/cortexproject/cortex@v0.6.1-0.20200228110116-92ab6cbe0995 requires
#14 11.52 	github.com/prometheus/alertmanager@v0.19.0 requires
#14 11.52 	github.com/prometheus/prometheus@v0.0.0-20190818123050-43acd0e2e93f: github.com/prometheus/prometheus(v0.0.0-20190818123050-43acd0e2e93f) depends on excluded k8s.io/client-go(v12.0.0+incompatible) with no newer version available
```