### PR TITLE
Improve proxy error handling 

### DIFF
--- a/pkg/influx/parser.go
+++ b/pkg/influx/parser.go
@@ -26,22 +26,22 @@ func parseInfluxLineReader(ctx context.Context, r *http.Request, maxSize int) ([
 	}
 
 	if !models.ValidPrecision(precision) {
-		return nil, NewProxyError(nil, http.StatusBadRequest, fmt.Sprintf("precision supplied is not valid: %s", precision))
+		return nil, NewProxyError(nil, fmt.Sprintf("precision supplied is not valid: %s", precision))
 	}
 
 	encoding := r.Header.Get("Content-Encoding")
 	reader, err := batchReadCloser(r.Body, encoding, int64(maxSize))
 	if err != nil {
-		return nil, NewProxyError(err, http.StatusBadRequest, "gzip compression failed")
+		return nil, NewProxyError(err, "gzip compression failed")
 	}
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return nil, NewProxyError(err, http.StatusBadRequest, "failed to read request body")
+		return nil, NewProxyError(err, "failed to read request body")
 	}
 
 	points, err := models.ParsePointsWithPrecision(data, time.Now().UTC(), precision)
 	if err != nil {
-		return nil, NewProxyError(err, http.StatusBadRequest, "failed to parse points")
+		return nil, NewProxyError(err, "failed to parse points")
 	}
 
 	return writeRequestFromInfluxPoints(points)

--- a/pkg/influx/parser_test.go
+++ b/pkg/influx/parser_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 )
 
 const maxSize = 100 << 10
@@ -140,7 +140,7 @@ func TestInvalidInput(t *testing.T) {
 
 			_, err := parseInfluxLineReader(context.Background(), req, maxSize)
 			require.Error(t, err)
-			assert.ErrorContains(t, err, tt.errorMessage)
+			assert.ErrorAs(t, err, &ProxyError{})
 		})
 	}
 }


### PR DESCRIPTION
This PR improves the error handling in the influx2cortex proxy by introducing a new error type for client-side errors, and adding logging to the error handler. 