### PR TITLE
Use remotewrite API 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine3.12 as build
+FROM golang:1.17.8-bullseye as build
 RUN apk add --update --no-cache git
 
 WORKDIR /go/src/github.com/grafana/influx2cortex

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.8-bullseye as build
+FROM golang:1.17.8-alpine as build
 RUN apk add --update --no-cache git
 
 WORKDIR /go/src/github.com/grafana/influx2cortex

--- a/cmd/influx2cortex/main.go
+++ b/cmd/influx2cortex/main.go
@@ -34,6 +34,8 @@ func Run() error {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
 	serverConfig.Log = logging.GoKit(logger)
 
+	reg := prometheus.DefaultRegisterer
+
 	httpAuthMiddleware := fakeauth.SetupAuthMiddleware(&serverConfig, enableAuth, nil)
 
 	server, err := server.New(serverConfig)
@@ -49,7 +51,7 @@ func Run() error {
 		return err
 	}
 
-	api, err := influx.NewAPI(logger, client)
+	api, err := influx.NewAPI(logger, client, reg)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to start API", "err", err)
 		return err

--- a/cmd/influx2cortex/main.go
+++ b/cmd/influx2cortex/main.go
@@ -42,10 +42,10 @@ func Run() error {
 		return err
 	}
 
-	remoteWriteRecorder := remotewrite.NewRecorder("influx", prometheus.DefaultRegisterer)
+	remoteWriteRecorder := remotewrite.NewRecorder("influx_proxy", prometheus.DefaultRegisterer)
 	client, err := remotewrite.NewClient(remoteWriteConfig, remoteWriteRecorder, nil)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to instantiate remotewrite.API for influx2cortex", "err", err)
+		level.Error(logger).Log("msg", "failed to instantiate remotewrite.API for influx2cortex", "err", err)
 		return err
 	}
 

--- a/cmd/influx2cortex/main.go
+++ b/cmd/influx2cortex/main.go
@@ -10,22 +10,23 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/influx2cortex/pkg/influx"
+	"github.com/grafana/influx2cortex/pkg/remotewrite"
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/server"
 )
 
 func Run() error {
 	var (
-		serverConfig server.Config
-		enableAuth   bool
-		apiConfig    influx.APIConfig
+		serverConfig      server.Config
+		enableAuth        bool
+		remoteWriteConfig remotewrite.Config
 	)
 
 	// Register flags.
 	flag.BoolVar(&enableAuth, "auth.enable", true, "enable X-Scope-OrgId header")
 	flagext.RegisterFlags(
 		&serverConfig,
-		&apiConfig,
+		&remoteWriteConfig,
 	)
 	flag.Parse()
 
@@ -40,7 +41,7 @@ func Run() error {
 		return err
 	}
 
-	api, err := influx.NewAPI(logger, apiConfig)
+	api, err := influx.NewAPI(logger, remoteWriteConfig)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to start API", "err", err)
 		return err

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/go-kit/log v0.2.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
+	github.com/golang/snappy v0.0.4
 	github.com/grafana/dskit v0.0.0-20220211095946-19921f863583
 	github.com/influxdata/influxdb/v2 v2.0.3
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/opentracing-contrib/go-stdlib v1.0.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
@@ -18,7 +20,10 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/weaveworks/common v0.0.0-20211222122857-933588f98737
+	go.uber.org/atomic v1.9.0
 	google.golang.org/grpc v1.44.0
+	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gotest.tools v2.2.0+incompatible
 )
 
@@ -30,7 +35,6 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/status v1.1.0 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
@@ -39,7 +43,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -51,18 +54,14 @@ require (
 	github.com/uber/jaeger-client-go v2.29.1+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/weaveworks/promrus v1.2.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220223155357-96fed51e1446 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 exclude (

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -69,8 +69,7 @@ func (a *API) handleSeriesPush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := a.client.Write(r.Context(), rwReq); err != nil {
-		level.Error(a.logger).Log("msg", "failed to push metric data", err, err)
-		http.Error(w, "failed to push metric data", http.StatusInternalServerError)
+		handleError(w, r, a.logger, err)
 		return
 	}
 

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -34,14 +34,7 @@ func (a *API) Register(server *server.Server, authMiddleware middleware.Interfac
 	server.HTTP.Handle("/api/v1/push/influx/write", authMiddleware.Wrap(http.HandlerFunc(a.handleSeriesPush)))
 }
 
-func NewAPI(logger log.Logger, config remotewrite.Config) (*API, error) {
-	remoteWriteRecorder := remotewrite.NewRecorder("influx", prometheus.DefaultRegisterer)
-
-	client, err := remotewrite.NewClient(config, remoteWriteRecorder, nil)
-	if err != nil {
-		level.Error(logger).Log("msg", "Failed to instantiate remotewrite.API for influx2cortex", "err", err)
-		return nil, err
-	}
+func NewAPI(logger log.Logger, client remotewrite.Client) (*API, error) {
 
 	recorder := NewRecorder(prometheus.NewRegistry())
 


### PR DESCRIPTION
This PR removes the use of an internal GRPC server and replaces it with the remotewrite API for handling requests.