### PR TITLE
Clean up error handling

### DIFF
--- a/pkg/influx/errors.go
+++ b/pkg/influx/errors.go
@@ -34,6 +34,7 @@ func handleError(w http.ResponseWriter, r *http.Request, logger log.Logger, err 
 	case errors.As(err, &errx):
 		httpErrString = errx.Message()
 		statusCode = errx.HTTPStatusCode()
+		err = errx
 	case errors.Is(err, context.DeadlineExceeded) || isGRPCTimeout(err):
 		httpErrString = "network timeout"
 		statusCode = http.StatusGatewayTimeout
@@ -59,9 +60,9 @@ func handleError(w http.ResponseWriter, r *http.Request, logger log.Logger, err 
 		statusCode = http.StatusInternalServerError
 	}
 	if statusCode < 500 {
-		level.Info(logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(errx))
+		level.Info(logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
 	} else if statusCode >= 500 {
-		level.Warn(logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(errx))
+		level.Warn(logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
 	}
 	http.Error(w, httpErrString, statusCode)
 }

--- a/pkg/influx/errors.go
+++ b/pkg/influx/errors.go
@@ -8,9 +8,10 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/grafana/influx2cortex/pkg/errorx"
-	"github.com/grpc-ecosystem/go-grpc-prometheus/packages/grpcstatus"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
+
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 func tryUnwrap(err error) error {

--- a/pkg/influx/parser.go
+++ b/pkg/influx/parser.go
@@ -27,7 +27,7 @@ func parseInfluxLineReader(ctx context.Context, r *http.Request, maxSize int) ([
 	}
 
 	if !models.ValidPrecision(precision) {
-		return nil, errorx.BadRequest{Err: fmt.Errorf("precision supplied is not valid: %s", precision)}
+		return nil, errorx.BadRequest{Msg: fmt.Sprintf("precision supplied is not valid: %s", precision)}
 	}
 
 	encoding := r.Header.Get("Content-Encoding")
@@ -73,7 +73,7 @@ func influxPointToTimeseries(pt models.Point) ([]cortexpb.TimeSeries, error) {
 
 	fields, err := pt.Fields()
 	if err != nil {
-		return nil, fmt.Errorf("error getting fields from point: %w", err)
+		return nil, errorx.Internal{Msg: "error getting fields from point", Err: err}
 	}
 	for field, v := range fields {
 		var value float64


### PR DESCRIPTION
All <500 errors should only be info-logged because they are expected and not a problem for the operation of the server.  >=500s are warnings because they are trouble, but do not represent unrecoverable server errors.

Note that we are returning error contents into the http error.  We should make sure that there's no chance that internal error details might get returned to clients.  I don't think that is a possibility but we should spot-check as development continues to make sure