### PR TITLE
Clean up metrics

### DIFF
--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -1,6 +1,7 @@
 package influx
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -8,7 +9,9 @@ import (
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/influx2cortex/pkg/errorx"
 	"github.com/grafana/influx2cortex/pkg/remotewrite"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/middleware"
@@ -51,8 +54,7 @@ func (a *API) handleSeriesPush(w http.ResponseWriter, r *http.Request) {
 
 	ts, err := parseInfluxLineReader(r.Context(), r, maxSize)
 	if err != nil {
-		a.recorder.measureProxyErrors(fmt.Sprintf("%T", err))
-		handleError(w, r, a.logger, err)
+		a.handleError(w, r, err)
 		return
 	}
 	a.recorder.measureMetricsParsed(len(ts))
@@ -70,8 +72,7 @@ func (a *API) handleSeriesPush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := a.client.Write(r.Context(), rwReq); err != nil {
-		a.recorder.measureProxyErrors(fmt.Sprintf("%T", err))
-		handleError(w, r, a.logger, err)
+		a.handleError(w, r, err)
 		return
 	}
 
@@ -79,4 +80,51 @@ func (a *API) handleSeriesPush(w http.ResponseWriter, r *http.Request) {
 	level.Debug(a.logger).Log("msg", "successful series write", "len", len(rwReq.Timeseries))
 
 	w.WriteHeader(http.StatusNoContent) // Needed for Telegraf, otherwise it tries to marshal JSON and considers the write a failure.
+}
+
+// handleError tries to extract an errorx.Error from the given error, logging
+// and setting the http response code as needed. All non-errorx errors are
+// considered internal errors. Please do not try to fix error categorization in
+// this function. All client errors should be categorized as an errorx at the
+// site where they are thrown.
+func (a *API) handleError(w http.ResponseWriter, r *http.Request, err error) {
+	var statusCode int
+	var httpErrString string
+	var errx errorx.Error
+	switch {
+	case errors.As(err, &errx):
+		httpErrString = errx.Message()
+		statusCode = errx.HTTPStatusCode()
+		err = errx
+	case errors.Is(err, context.DeadlineExceeded) || isGRPCTimeout(err):
+		httpErrString = "network timeout"
+		statusCode = http.StatusGatewayTimeout
+	case errors.Is(err, context.Canceled):
+		// Note: It seems unlikely this can happen other than as a timeout, so we
+		// should call it an internal error.
+		httpErrString = "request cancelled"
+		statusCode = http.StatusInternalServerError
+	case isNetworkTimeout(err):
+		if r.Body != nil {
+			// Try to read 1 byte from the request body. If it fails with the same error
+			// it means the timeout occurred while reading the request body, so it's a 408.
+			if _, readErr := r.Body.Read([]byte{0}); isNetworkTimeout(readErr) {
+				httpErrString = "response timeout"
+				statusCode = http.StatusRequestTimeout
+				break
+			}
+			httpErrString = "network timeout"
+			statusCode = http.StatusGatewayTimeout
+		}
+	default:
+		httpErrString = "uncategorized error"
+		statusCode = http.StatusInternalServerError
+	}
+	if statusCode < 500 {
+		level.Info(a.logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
+	} else if statusCode >= 500 {
+		level.Warn(a.logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
+	}
+	a.recorder.measureProxyErrors(fmt.Sprintf("%T", err))
+	http.Error(w, httpErrString, statusCode)
 }

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -1,17 +1,13 @@
 package influx
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/influx2cortex/pkg/errorx"
 	"github.com/grafana/influx2cortex/pkg/remotewrite"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/weaveworks/common/middleware"
@@ -80,51 +76,4 @@ func (a *API) handleSeriesPush(w http.ResponseWriter, r *http.Request) {
 	level.Debug(a.logger).Log("msg", "successful series write", "len", len(rwReq.Timeseries))
 
 	w.WriteHeader(http.StatusNoContent) // Needed for Telegraf, otherwise it tries to marshal JSON and considers the write a failure.
-}
-
-// handleError tries to extract an errorx.Error from the given error, logging
-// and setting the http response code as needed. All non-errorx errors are
-// considered internal errors. Please do not try to fix error categorization in
-// this function. All client errors should be categorized as an errorx at the
-// site where they are thrown.
-func (a *API) handleError(w http.ResponseWriter, r *http.Request, err error) {
-	var statusCode int
-	var httpErrString string
-	var errx errorx.Error
-	switch {
-	case errors.As(err, &errx):
-		httpErrString = errx.Message()
-		statusCode = errx.HTTPStatusCode()
-		err = errx
-	case errors.Is(err, context.DeadlineExceeded) || isGRPCTimeout(err):
-		httpErrString = "network timeout"
-		statusCode = http.StatusGatewayTimeout
-	case errors.Is(err, context.Canceled):
-		// Note: It seems unlikely this can happen other than as a timeout, so we
-		// should call it an internal error.
-		httpErrString = "request cancelled"
-		statusCode = http.StatusInternalServerError
-	case isNetworkTimeout(err):
-		if r.Body != nil {
-			// Try to read 1 byte from the request body. If it fails with the same error
-			// it means the timeout occurred while reading the request body, so it's a 408.
-			if _, readErr := r.Body.Read([]byte{0}); isNetworkTimeout(readErr) {
-				httpErrString = "response timeout"
-				statusCode = http.StatusRequestTimeout
-				break
-			}
-			httpErrString = "network timeout"
-			statusCode = http.StatusGatewayTimeout
-		}
-	default:
-		httpErrString = "uncategorized error"
-		statusCode = http.StatusInternalServerError
-	}
-	if statusCode < 500 {
-		level.Info(a.logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
-	} else if statusCode >= 500 {
-		level.Warn(a.logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
-	}
-	a.recorder.measureProxyErrors(fmt.Sprintf("%T", err))
-	http.Error(w, httpErrString, statusCode)
 }

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -1,6 +1,7 @@
 package influx
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -50,7 +51,7 @@ func (a *API) handleSeriesPush(w http.ResponseWriter, r *http.Request) {
 
 	ts, err := parseInfluxLineReader(r.Context(), r, maxSize)
 	if err != nil {
-		a.recorder.measureProxyErrors("can't parse body")
+		a.recorder.measureProxyErrors(fmt.Sprintf("%T", err))
 		handleError(w, r, a.logger, err)
 		return
 	}
@@ -69,7 +70,7 @@ func (a *API) handleSeriesPush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := a.client.Write(r.Context(), rwReq); err != nil {
-		a.recorder.measureProxyErrors("error writing data")
+		a.recorder.measureProxyErrors(fmt.Sprintf("%T", err))
 		handleError(w, r, a.logger, err)
 		return
 	}

--- a/pkg/influx/errors.go
+++ b/pkg/influx/errors.go
@@ -1,13 +1,8 @@
 package influx
 
 import (
-	"context"
 	"net"
-	"net/http"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
-	"github.com/grafana/influx2cortex/pkg/errorx"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 
@@ -19,52 +14,6 @@ func tryUnwrap(err error) error {
 		return wrapped.Unwrap()
 	}
 	return err
-}
-
-// handleError tries to extract an errorx.Error from the given error, logging
-// and setting the http response code as needed. All non-errorx errors are
-// considered internal errors. Please do not try to fix error categorization in
-// this function. All client errors should be categorized as an errorx at the
-// site where they are thrown.
-func handleError(w http.ResponseWriter, r *http.Request, logger log.Logger, err error) {
-	var statusCode int
-	var httpErrString string
-	var errx errorx.Error
-	switch {
-	case errors.As(err, &errx):
-		httpErrString = errx.Message()
-		statusCode = errx.HTTPStatusCode()
-		err = errx
-	case errors.Is(err, context.DeadlineExceeded) || isGRPCTimeout(err):
-		httpErrString = "network timeout"
-		statusCode = http.StatusGatewayTimeout
-	case errors.Is(err, context.Canceled):
-		// Note: It seems unlikely this can happen other than as a timeout, so we
-		// should call it an internal error.
-		httpErrString = "request cancelled"
-		statusCode = http.StatusInternalServerError
-	case isNetworkTimeout(err):
-		if r.Body != nil {
-			// Try to read 1 byte from the request body. If it fails with the same error
-			// it means the timeout occurred while reading the request body, so it's a 408.
-			if _, readErr := r.Body.Read([]byte{0}); isNetworkTimeout(readErr) {
-				httpErrString = "response timeout"
-				statusCode = http.StatusRequestTimeout
-				break
-			}
-			httpErrString = "network timeout"
-			statusCode = http.StatusGatewayTimeout
-		}
-	default:
-		httpErrString = "uncategorized error"
-		statusCode = http.StatusInternalServerError
-	}
-	if statusCode < 500 {
-		level.Info(logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
-	} else if statusCode >= 500 {
-		level.Warn(logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
-	}
-	http.Error(w, httpErrString, statusCode)
 }
 
 func isNetworkTimeout(err error) bool {

--- a/pkg/influx/errors.go
+++ b/pkg/influx/errors.go
@@ -1,8 +1,13 @@
 package influx
 
 import (
+	"context"
+	"fmt"
 	"net"
+	"net/http"
 
+	"github.com/go-kit/kit/log/level"
+	"github.com/grafana/influx2cortex/pkg/errorx"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 
@@ -14,6 +19,53 @@ func tryUnwrap(err error) error {
 		return wrapped.Unwrap()
 	}
 	return err
+}
+
+// handleError tries to extract an errorx.Error from the given error, logging
+// and setting the http response code as needed. All non-errorx errors are
+// considered internal errors. Please do not try to fix error categorization in
+// this function. All client errors should be categorized as an errorx at the
+// site where they are thrown.
+func (a *API) handleError(w http.ResponseWriter, r *http.Request, err error) {
+	var statusCode int
+	var httpErrString string
+	var errx errorx.Error
+	switch {
+	case errors.As(err, &errx):
+		httpErrString = errx.Message()
+		statusCode = errx.HTTPStatusCode()
+		err = errx
+	case errors.Is(err, context.DeadlineExceeded) || isGRPCTimeout(err):
+		httpErrString = "network timeout"
+		statusCode = http.StatusGatewayTimeout
+	case errors.Is(err, context.Canceled):
+		// Note: It seems unlikely this can happen other than as a timeout, so we
+		// should call it an internal error.
+		httpErrString = "request cancelled"
+		statusCode = http.StatusInternalServerError
+	case isNetworkTimeout(err):
+		if r.Body != nil {
+			// Try to read 1 byte from the request body. If it fails with the same error
+			// it means the timeout occurred while reading the request body, so it's a 408.
+			if _, readErr := r.Body.Read([]byte{0}); isNetworkTimeout(readErr) {
+				httpErrString = "response timeout"
+				statusCode = http.StatusRequestTimeout
+				break
+			}
+			httpErrString = "network timeout"
+			statusCode = http.StatusGatewayTimeout
+		}
+	default:
+		httpErrString = "uncategorized error"
+		statusCode = http.StatusInternalServerError
+	}
+	if statusCode < 500 {
+		level.Info(a.logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
+	} else if statusCode >= 500 {
+		level.Warn(a.logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
+	}
+	a.recorder.measureProxyErrors(fmt.Sprintf("%T", err))
+	http.Error(w, httpErrString, statusCode)
 }
 
 func isNetworkTimeout(err error) bool {

--- a/pkg/influx/mock_recorder_test.go
+++ b/pkg/influx/mock_recorder_test.go
@@ -13,22 +13,22 @@ type MockRecorder struct {
 	mock.Mock
 }
 
-// measureConversionDuration provides a mock function with given fields: user, duration
-func (_m *MockRecorder) measureConversionDuration(user string, duration time.Duration) {
-	_m.Called(user, duration)
+// measureConversionDuration provides a mock function with given fields: duration
+func (_m *MockRecorder) measureConversionDuration(duration time.Duration) {
+	_m.Called(duration)
 }
 
-// measureIncomingPoints provides a mock function with given fields: user, count
-func (_m *MockRecorder) measureIncomingPoints(user string, count int) {
-	_m.Called(user, count)
+// measureMetricsParsed provides a mock function with given fields: count
+func (_m *MockRecorder) measureMetricsParsed(count int) {
+	_m.Called(count)
 }
 
-// measureReceivedPoints provides a mock function with given fields: user, count
-func (_m *MockRecorder) measureReceivedPoints(user string, count int) {
-	_m.Called(user, count)
+// measureMetricsWritten provides a mock function with given fields: count
+func (_m *MockRecorder) measureMetricsWritten(count int) {
+	_m.Called(count)
 }
 
-// measureRejectedPoints provides a mock function with given fields: user, reason
-func (_m *MockRecorder) measureRejectedPoints(user string, reason string) {
-	_m.Called(user, reason)
+// measureProxyErrors provides a mock function with given fields: reason
+func (_m *MockRecorder) measureProxyErrors(reason string) {
+	_m.Called(reason)
 }

--- a/pkg/influx/recorder.go
+++ b/pkg/influx/recorder.go
@@ -65,7 +65,7 @@ func (r prometheusRecorder) measureMetricsParsed(count int) {
 
 // measureMetricsParsed measures the total amount of metrics written.
 func (r prometheusRecorder) measureMetricsWritten(count int) {
-	r.proxyMetricsParsed.WithLabelValues().Add(float64(count))
+	r.proxyMetricsWritten.WithLabelValues().Add(float64(count))
 }
 
 // measureProxyErrors measures the total amount of errors encountered.

--- a/pkg/influx/recorder.go
+++ b/pkg/influx/recorder.go
@@ -29,7 +29,7 @@ func NewRecorder(reg prometheus.Registerer) Recorder {
 		proxyErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: prefix,
 			Name:      "proxy_errors_total",
-			Help:      "The total number of errors.",
+			Help:      "The total number of errors, sliced by the go error type returned.",
 		}, []string{"reason"}),
 		proxyMetricsWritten: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: prefix,

--- a/pkg/influx/recorder_test.go
+++ b/pkg/influx/recorder_test.go
@@ -34,15 +34,28 @@ influxdb_proxy_ingester_metrics_parsed_total 3
 		},
 		"Measure rejected samples": {
 			measure: func(r Recorder) {
-				r.measureMetricsRejected(3)
+				r.measureProxyErrors("reason")
 			},
 			expMetricNames: []string{
-				"influxdb_proxy_ingester_metrics_rejected_total",
+				"influxdb_proxy_ingester_proxy_errors_total",
 			},
 			expMetrics: `
-# HELP influxdb_proxy_ingester_metrics_rejected_total The total number of metrics that were rejected.
-# TYPE influxdb_proxy_ingester_metrics_rejected_total counter
-influxdb_proxy_ingester_metrics_rejected_total 3
+# HELP influxdb_proxy_ingester_proxy_errors_total The total number of errors.
+# TYPE influxdb_proxy_ingester_proxy_errors_total counter
+influxdb_proxy_ingester_proxy_errors_total{reason="reason"} 1
+`,
+		},
+		"Measure written samples": {
+			measure: func(r Recorder) {
+				r.measureMetricsWritten(3)
+			},
+			expMetricNames: []string{
+				"influxdb_proxy_ingester_metrics_written_total",
+			},
+			expMetrics: `
+# HELP influxdb_proxy_ingester_metrics_written_total The total number of metrics that have been written.
+# TYPE influxdb_proxy_ingester_metrics_written_total counter
+influxdb_proxy_ingester_metrics_written_total 3
 `,
 		},
 		"Measure conversion duration": {

--- a/pkg/influx/recorder_test.go
+++ b/pkg/influx/recorder_test.go
@@ -40,7 +40,7 @@ influxdb_proxy_ingester_metrics_parsed_total 3
 				"influxdb_proxy_ingester_proxy_errors_total",
 			},
 			expMetrics: `
-# HELP influxdb_proxy_ingester_proxy_errors_total The total number of errors.
+# HELP influxdb_proxy_ingester_proxy_errors_total The total number of errors, sliced by the go error type returned.
 # TYPE influxdb_proxy_ingester_proxy_errors_total counter
 influxdb_proxy_ingester_proxy_errors_total{reason="reason"} 1
 `,


### PR DESCRIPTION
This PR updates the recorder for metrics for influx2cortex. It adds a metric for metrics that have been written, as well as changes from measuring number of rejected metrics to measuring number of errors and error types. 