### PR TITLE
Add authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
+	gotest.tools v2.2.0+incompatible // indirect
 )
 
 exclude (

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -120,7 +120,6 @@ func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*server.Se
 
 // NewProxy creates a new remotewrite client
 func NewProxy(conf ProxyConfig) (*server.Server, error) {
-
 	remoteWriteRecorder := remotewrite.NewRecorder("influx_proxy", conf.Registerer)
 	client, err := remotewrite.NewClient(conf.RemoteWriteConfig, remoteWriteRecorder, nil)
 	if err != nil {

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -80,6 +80,8 @@ type ProxyConfig struct {
 	Registerer        prometheus.Registerer
 }
 
+// newProxyWithClient creates the influx API server with the given config options and
+// the specified remotewrite client. It returns the HTTP server that is ready to Run.
 func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*server.Server, error) {
 	recorder := NewRecorder(conf.Registerer)
 
@@ -116,8 +118,7 @@ func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*server.Se
 	return server, nil
 }
 
-// NewProxy creates the influx API server with the given config options. It
-// returns the HTTP server that is ready to Run.
+// NewProxy creates a new remotewrite client
 func NewProxy(conf ProxyConfig) (*server.Server, error) {
 
 	remoteWriteRecorder := remotewrite.NewRecorder("influx_proxy", conf.Registerer)

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -81,7 +81,7 @@ type ProxyConfig struct {
 }
 
 func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*server.Server, error) {
-	recorder := NewRecorder(prometheus.DefaultRegisterer)
+	recorder := NewRecorder(conf.Registerer)
 
 	var authMiddleware middleware.Interface
 	if conf.EnableAuth {

--- a/pkg/influx/auth_test.go
+++ b/pkg/influx/auth_test.go
@@ -1,0 +1,96 @@
+package influx
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/influx2cortex/pkg/remotewrite"
+	"github.com/grafana/influx2cortex/pkg/server"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/common/user"
+)
+
+func TestAuthentication(t *testing.T) {
+	tests := []struct {
+		name         string
+		url          string
+		data         string
+		enableAuth   bool
+		orgID        string
+		expectedCode int
+	}{
+		{
+			name:         "test auth enabled valid org ID",
+			url:          "/write",
+			data:         "measurement,t1=v1 f1=2 1465839830100400200",
+			enableAuth:   true,
+			orgID:        "valid",
+			expectedCode: http.StatusNoContent,
+		},
+		{
+			name:         "test auth enabled invalid org ID",
+			url:          "/write",
+			data:         "measurement,t1=v1 f1=2 1465839830100400200",
+			enableAuth:   true,
+			orgID:        "",
+			expectedCode: http.StatusUnauthorized,
+		},
+		{
+			name:         "test auth disabled",
+			url:          "/write",
+			data:         "measurement,t1=v1 f1=2 1465839830100400200",
+			enableAuth:   false,
+			orgID:        "fake",
+			expectedCode: http.StatusNoContent,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			serverConfig := server.Config{
+				HTTPListenAddress: "127.0.0.1",
+				HTTPListenPort:    0, // Request system available port
+			}
+			apiConfig := ProxyConfig{
+				HTTPConfig:        serverConfig,
+				EnableAuth:        tt.enableAuth,
+				RemoteWriteConfig: remotewrite.Config{},
+				Logger:            log.NewNopLogger(),
+			}
+
+			server, err := NewProxy(apiConfig)
+			require.NoError(t, err)
+
+			go func() {
+				require.NoError(t, server.Run())
+			}()
+
+			defer server.Shutdown(nil)
+
+			url := fmt.Sprintf("http://%s/api/v1/push/influx/write", server.Addr())
+			req, err := http.NewRequest("POST", url, bytes.NewReader([]byte("measurement,t1=v1 f1=2 1465839830100400200")))
+			require.NoError(t, err)
+			req = req.WithContext(user.InjectOrgID(req.Context(), tt.orgID))
+			err = user.InjectOrgIDIntoHTTPRequest(req.Context(), req)
+			require.NoError(t, err)
+			require.Equal(t, req.Header.Get(user.OrgIDHeaderName), tt.orgID)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedCode, resp.StatusCode)
+		})
+	}
+}
+
+func NewMockRecorder() *MockRecorder {
+	recorderMock := &MockRecorder{}
+	recorderMock.On("measureMetricsParsed", 1).Return(nil)
+	recorderMock.On("measureMetricsWritten", 1).Return(nil)
+	recorderMock.On("measureConversionDuration", mock.MatchedBy(func(duration time.Duration) bool { return duration > 0 })).Return(nil)
+	return recorderMock
+}


### PR DESCRIPTION
This PR replaces the fakeAuth middleware with middleware.Authenticate user, so that authentication can be done. The enableAuth flag is still available.