### PR TITLE
Split Proxy from API

### DIFF
--- a/cmd/influx2cortex/main.go
+++ b/cmd/influx2cortex/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/influx2cortex/pkg/influx"
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/signals"
@@ -24,31 +26,29 @@ func main() {
 
 	service, err := influx.NewProxy(conf)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error instantiating influx2cortex proxy: %s", err)
+		_, _ = fmt.Fprintf(os.Stderr, "error instantiating influx2cortex proxy: %s\n", err)
 		os.Exit(1)
 	}
 
-	err = service.StartAsync(context.Background())
+	servCtx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	err = services.StartAndAwaitRunning(servCtx, service)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error starting influx2cortex: %s", err)
-		os.Exit(1)
-	}
-	err = service.AwaitRunning(context.Background())
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error running influx2cortex: %s", err)
+		_, _ = fmt.Fprintf(os.Stderr, "error running influx2cortex: %s\n", err)
 		os.Exit(1)
 	}
 
 	// Look for SIGTERM and stop the server if we get it
-	handler := signals.NewHandler(logging.GoKit(p.config.Logger))
+	handler := signals.NewHandler(logging.GoKit(service.Logger))
 	go func() {
 		handler.Loop()
-		service.StopAsync()
+		services.StopAndAwaitTerminated(context.Background(), service)
 	}()
 
 	err = service.AwaitTerminated(context.Background())
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error running influx2cortex: %s", err)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		_, _ = fmt.Fprintf(os.Stderr, "error running influx2cortex????: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/influx2cortex/main.go
+++ b/cmd/influx2cortex/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	err = service.AwaitTerminated(context.Background())
 	if err != nil && !errors.Is(err, context.Canceled) {
-		_, _ = fmt.Fprintf(os.Stderr, "error running influx2cortex????: %s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "error running influx2cortex: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/influx2cortex/main.go
+++ b/cmd/influx2cortex/main.go
@@ -43,7 +43,7 @@ func main() {
 	handler := signals.NewHandler(logging.GoKit(service.Logger))
 	go func() {
 		handler.Loop()
-		services.StopAndAwaitTerminated(context.Background(), service)
+		service.StopAsync()
 	}()
 
 	err = service.AwaitTerminated(context.Background())

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -83,6 +83,10 @@ type ProxyConfig struct {
 // newProxyWithClient creates the influx API server with the given config options and
 // the specified remotewrite client. It returns the HTTP server that is ready to Run.
 func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*server.Server, error) {
+	if conf.Registerer == nil {
+		return nil, fmt.Errorf("must specify a Registerer, perhaps prometheus.DefaultRegisterer")
+	}
+
 	recorder := NewRecorder(conf.Registerer)
 
 	var authMiddleware middleware.Interface

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -1,7 +1,6 @@
 package influx
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -10,11 +9,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/grafana/influx2cortex/pkg/remotewrite"
 	"github.com/grafana/influx2cortex/pkg/route"
-	"github.com/grafana/influx2cortex/pkg/server"
-	"github.com/grafana/influx2cortex/pkg/server/middleware"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/weaveworks/common/logging"
-	"github.com/weaveworks/common/signals"
 )
 
 type API struct {
@@ -68,67 +62,4 @@ func (a *API) handleSeriesPush(w http.ResponseWriter, r *http.Request) {
 	a.recorder.measureMetricsWritten(len(rwReq.Timeseries))
 
 	w.WriteHeader(http.StatusNoContent) // Needed for Telegraf, otherwise it tries to marshal JSON and considers the write a failure.
-}
-
-// ProxyConfig holds objects needed to start running an influx2cortex proxy
-// server.
-type ProxyConfig struct {
-	HTTPConfig        server.Config
-	EnableAuth        bool
-	RemoteWriteConfig remotewrite.Config
-	Logger            log.Logger
-	Registerer        prometheus.Registerer
-}
-
-// newProxyWithClient creates the influx API server with the given config options and
-// the specified remotewrite client. It returns the HTTP server that is ready to Run.
-func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*server.Server, error) {
-	if conf.Registerer == nil {
-		return nil, fmt.Errorf("must specify a Registerer, perhaps prometheus.DefaultRegisterer")
-	}
-
-	recorder := NewRecorder(conf.Registerer)
-
-	var authMiddleware middleware.Interface
-	if conf.EnableAuth {
-		authMiddleware = middleware.NewHTTPAuth(conf.Logger)
-	} else {
-		authMiddleware = middleware.HTTPFakeAuth{}
-	}
-
-	server, err := server.NewServer(conf.Logger, conf.HTTPConfig, mux.NewRouter(), []middleware.Interface{authMiddleware})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create http server: %w", err)
-	}
-
-	api, err := NewAPI(conf.Logger, client, recorder)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create influx API: %w", err)
-	}
-
-	api.Register(server.Router)
-	err = recorder.RegisterVersionBuildTimestamp()
-	if err != nil {
-		return nil, fmt.Errorf("could not register version build timestamp: %w", err)
-	}
-
-	// Look for SIGTERM and stop the server if we get it
-	handler := signals.NewHandler(logging.GoKit(conf.Logger))
-	go func() {
-		handler.Loop()
-		server.Shutdown(nil)
-	}()
-
-	return server, nil
-}
-
-// NewProxy creates a new remotewrite client
-func NewProxy(conf ProxyConfig) (*server.Server, error) {
-	remoteWriteRecorder := remotewrite.NewRecorder("influx_proxy", conf.Registerer)
-	client, err := remotewrite.NewClient(conf.RemoteWriteConfig, remoteWriteRecorder, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create remotewrite.API: %w", err)
-	}
-
-	return newProxyWithClient(conf, client)
 }

--- a/pkg/influx/auth_test.go
+++ b/pkg/influx/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/influx2cortex/pkg/errorx"
 	"github.com/grafana/influx2cortex/pkg/remotewrite"
 	"github.com/grafana/influx2cortex/pkg/remotewrite/remotewritemock"
@@ -85,9 +86,7 @@ func TestAuthentication(t *testing.T) {
 
 			service, err := newProxyWithClient(apiConfig, remoteWriteMock)
 			require.NoError(t, err)
-			require.NoError(t, service.StartAsync(context.Background()))
-			require.NoError(t, service.AwaitRunning(context.Background()))
-
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), service))
 			defer service.StopAsync()
 
 			url := fmt.Sprintf("http://%s/api/v1/push/influx/write", service.Addr())

--- a/pkg/influx/proxy.go
+++ b/pkg/influx/proxy.go
@@ -1,0 +1,120 @@
+package influx
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/influx2cortex/pkg/remotewrite"
+	"github.com/grafana/influx2cortex/pkg/server"
+	"github.com/grafana/influx2cortex/pkg/server/middleware"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// ProxyConfig holds objects needed to start running an influx2cortex proxy
+// server.
+type ProxyConfig struct {
+	// HTTPConfig is the configuration for the underlying http server. Usually
+	// initialized by flag values via flagext.RegisterFlags.
+	HTTPConfig server.Config
+	// EnableAuth determines if the server will reject incoming requests that do
+	// not have X-Scope-OrgID set.
+	EnableAuth bool
+	// RemoteWriteConfig is the configuration for the underlying http server. Usually
+	// initialized by flag values via flagext.RegisterFlags.
+	RemoteWriteConfig remotewrite.Config
+	// Logger is the object that will do the logging for the server. If nil, will
+	// use a LogfmtLogger on stdout.
+	Logger log.Logger
+	// Registerer registers metrics Collectors. If left nil, will use
+	// prometheus.DefaultRegisterer.
+	Registerer prometheus.Registerer
+}
+
+// ProxyService is the actual Influx Proxy dskit service.
+type ProxyService struct {
+	services.Service
+
+	config     ProxyConfig
+	httpServer *server.Server
+	logger     log.Logger
+}
+
+// NewProxy creates a new remotewrite client
+func NewProxy(conf ProxyConfig) (*ProxyService, error) {
+	if conf.Registerer == nil {
+		conf.Registerer = prometheus.DefaultRegisterer
+	}
+	remoteWriteRecorder := remotewrite.NewRecorder("influx_proxy", conf.Registerer)
+	client, err := remotewrite.NewClient(conf.RemoteWriteConfig, remoteWriteRecorder, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create remotewrite.API: %w", err)
+	}
+
+	return newProxyWithClient(conf, client)
+}
+
+// newProxyWithClient creates the influx API server with the given config options and
+// the specified remotewrite client. It returns the HTTP server that is ready to Run.
+func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*ProxyService, error) {
+	if conf.Logger == nil {
+		conf.Logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+	}
+
+	recorder := NewRecorder(conf.Registerer)
+
+	var authMiddleware middleware.Interface
+	if conf.EnableAuth {
+		authMiddleware = middleware.NewHTTPAuth(conf.Logger)
+	} else {
+		authMiddleware = middleware.HTTPFakeAuth{}
+	}
+
+	server, err := server.NewServer(conf.Logger, conf.HTTPConfig, mux.NewRouter(), []middleware.Interface{authMiddleware})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create http server: %w", err)
+	}
+
+	api, err := NewAPI(conf.Logger, client, recorder)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create influx API: %w", err)
+	}
+
+	api.Register(server.Router)
+	err = recorder.RegisterVersionBuildTimestamp()
+	if err != nil {
+		return nil, fmt.Errorf("could not register version build timestamp: %w", err)
+	}
+
+	p := &ProxyService{
+		config:     conf,
+		httpServer: server,
+		logger:     conf.Logger,
+	}
+	p.Service = services.NewBasicService(p.start, p.run, p.stop)
+	return p, nil
+}
+
+func (p *ProxyService) Addr() net.Addr {
+	return p.httpServer.Addr()
+}
+
+func (p *ProxyService) start(_ context.Context) error {
+	return nil
+}
+
+func (p *ProxyService) stop(_ error) error {
+	p.httpServer.Shutdown(nil)
+	return nil
+}
+
+func (p *ProxyService) run(_ context.Context) error {
+	go func() {
+		p.httpServer.Run()
+	}()
+	return nil
+}


### PR DESCRIPTION
In our other proxies, the API is the object that handles receiving and handling requests.  The service that actually spins up a server and listens for connections that get handed to the API is the proxy object.  This change splits these pieces apart so they are more clearly separated.

It also implements the proxy as a proper dskit service, which is the standard for Grafana services. It also provides defaults for the logger and registerer so callers don't have to specify obvious defaults.