### PR TITLE
Add /metrics endpoint

### DIFF
--- a/cmd/influx2cortex/main.go
+++ b/cmd/influx2cortex/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 	appServices = append(appServices, proxyService)
 
-	internalService, err := internalserver.NewService(internalServerConfig, proxyService.Logger)
+	internalService, err := internalserver.NewService(internalServerConfig, logger)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error instantiating internal server: %s\n", err)
 		os.Exit(1)
@@ -61,7 +61,7 @@ func main() {
 	}
 
 	// Look for SIGTERM and stop the server if we get it
-	handler := signals.NewHandler(logging.GoKit(proxyService.Logger))
+	handler := signals.NewHandler(logging.GoKit(logger))
 	go func() {
 		handler.Loop()
 		for _, service := range appServices {

--- a/cmd/influx2cortex/main.go
+++ b/cmd/influx2cortex/main.go
@@ -5,51 +5,76 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"os"
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/influx2cortex/pkg/influx"
+	"github.com/grafana/influx2cortex/pkg/internalserver"
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/signals"
 )
 
 func main() {
-	conf := influx.ProxyConfig{}
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+	promRegisterer := prometheus.DefaultRegisterer
 
-	flag.BoolVar(&conf.EnableAuth, "auth.enable", true, "require X-Scope-OrgId header")
+	proxyConfig := influx.ProxyConfig{
+		Logger:     logger,
+		Registerer: promRegisterer,
+	}
+	internalServerConfig := internalserver.ServiceConfig{}
+
 	flagext.RegisterFlags(
-		&conf.HTTPConfig,
-		&conf.RemoteWriteConfig,
+		&proxyConfig,
+		&internalServerConfig,
 	)
 	flag.Parse()
 
-	service, err := influx.NewProxy(conf)
+	appServices := make([]services.Service, 0)
+
+	proxyService, err := influx.NewProxy(proxyConfig)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error instantiating influx2cortex proxy: %s\n", err)
 		os.Exit(1)
 	}
+	appServices = append(appServices, proxyService)
 
-	servCtx, cancelFn := context.WithCancel(context.Background())
+	internalService, err := internalserver.NewService(internalServerConfig, proxyService.Logger)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error instantiating internal server: %s\n", err)
+		os.Exit(1)
+	}
+	appServices = append(appServices, internalService)
+
+	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
-	err = services.StartAndAwaitRunning(servCtx, service)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error running influx2cortex: %s\n", err)
-		os.Exit(1)
+	for _, service := range appServices {
+		err = services.StartAndAwaitRunning(ctx, service)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error starting service: %s\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Look for SIGTERM and stop the server if we get it
-	handler := signals.NewHandler(logging.GoKit(service.Logger))
+	handler := signals.NewHandler(logging.GoKit(proxyService.Logger))
 	go func() {
 		handler.Loop()
-		service.StopAsync()
+		for _, service := range appServices {
+			service.StopAsync()
+		}
 	}()
 
-	err = service.AwaitTerminated(context.Background())
-	if err != nil && !errors.Is(err, context.Canceled) {
-		_, _ = fmt.Fprintf(os.Stderr, "error running influx2cortex: %s\n", err)
-		os.Exit(1)
+	for _, service := range appServices {
+		err = service.AwaitTerminated(context.Background())
+		if err != nil && !errors.Is(err, context.Canceled) {
+			_, _ = fmt.Fprintf(os.Stderr, "error in service: %s\n", err)
+			os.Exit(1)
+		}
 	}
 
 	os.Exit(0)

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -9,9 +9,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/grafana/influx2cortex/pkg/remotewrite"
 	"github.com/grafana/influx2cortex/pkg/route"
-
-	"github.com/grafana/influx2cortex/pkg/server/middleware"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type API struct {
@@ -20,11 +17,10 @@ type API struct {
 	recorder Recorder
 }
 
-func (a *API) Register(router *mux.Router, authMiddleware middleware.Interface) {
+func (a *API) Register(router *mux.Router) {
 	registerer := route.NewMuxRegisterer(router)
 
-	registerer.RegisterRoute("/api/v1/push/influx/write", authMiddleware.Wrap(http.HandlerFunc(a.handleSeriesPush)), http.MethodPost)
-	registerer.RegisterRoute("/metrics", promhttp.Handler(), http.MethodGet)
+	registerer.RegisterRoute("/api/v1/push/influx/write", http.HandlerFunc(a.handleSeriesPush), http.MethodPost)
 }
 
 func NewAPI(logger log.Logger, client remotewrite.Client, recorder Recorder) (*API, error) {

--- a/pkg/influx/proxy.go
+++ b/pkg/influx/proxy.go
@@ -47,7 +47,7 @@ func (c *ProxyConfig) RegisterFlags(flags *flag.FlagSet) {
 type ProxyService struct {
 	services.Service
 
-	Logger log.Logger
+	logger log.Logger
 
 	config  ProxyConfig
 	server  *server.Server
@@ -101,7 +101,7 @@ func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*ProxyServ
 	}
 
 	p := &ProxyService{
-		Logger:  conf.Logger,
+		logger:  conf.Logger,
 		config:  conf,
 		server:  server,
 		errChan: make(chan error, 1),

--- a/pkg/influx/proxy.go
+++ b/pkg/influx/proxy.go
@@ -75,7 +75,7 @@ func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*ProxyServ
 		authMiddleware = middleware.HTTPFakeAuth{}
 	}
 
-	server, err := server.NewServer(conf.Logger, conf.HTTPConfig, mux.NewRouter(), []middleware.Interface{authMiddleware})
+	server, err := server.NewServer(conf.Logger, conf.HTTPConfig, mux.NewRouter(), []middleware.Interface{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create http server: %w", err)
 	}
@@ -85,7 +85,7 @@ func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*ProxyServ
 		return nil, fmt.Errorf("failed to create influx API: %w", err)
 	}
 
-	api.Register(server.Router)
+	api.Register(server.Router, authMiddleware)
 	err = recorder.RegisterVersionBuildTimestamp()
 	if err != nil {
 		return nil, fmt.Errorf("could not register version build timestamp: %w", err)

--- a/pkg/influx/proxy.go
+++ b/pkg/influx/proxy.go
@@ -106,7 +106,7 @@ func newProxyWithClient(conf ProxyConfig, client remotewrite.Client) (*ProxyServ
 		server:  server,
 		errChan: make(chan error, 1),
 	}
-	p.Service = services.NewBasicService(p.start, p.run, p.stop)
+	p.Service = services.NewBasicService(p.start, p.run, p.stop).WithName("influx-write-proxy")
 	return p, nil
 }
 

--- a/pkg/internalserver/service.go
+++ b/pkg/internalserver/service.go
@@ -29,7 +29,7 @@ type ServiceConfig struct {
 func (c *ServiceConfig) RegisterFlags(flags *flag.FlagSet) {
 	flags.StringVar(&c.HTTPListenAddress, "internalserver.http-listen-address", DefaultListenAddress, "Sets the listen address for the internal http server")
 	flags.IntVar(&c.HTTPListenPort, "internalserver.http-listen-port", DefaultListenPort, "Sets listen address port for the internal http server")
-	flags.DurationVar(&c.GracefulShutdownTimeout, "internalserver.graceful-shutdown-timeout", DefaultGracefulShutdownTimeout, "Graceful shutdown period; defaults to 5 seconds")
+	flags.DurationVar(&c.GracefulShutdownTimeout, "internalserver.graceful-shutdown-timeout", DefaultGracefulShutdownTimeout, "Graceful shutdown period")
 }
 
 type Service struct {

--- a/pkg/internalserver/service.go
+++ b/pkg/internalserver/service.go
@@ -35,7 +35,7 @@ func (c *ServiceConfig) RegisterFlags(flags *flag.FlagSet) {
 type Service struct {
 	services.Service
 
-	Logger gokitlog.Logger
+	logger gokitlog.Logger
 
 	config  ServiceConfig
 	server  *http.Server
@@ -50,9 +50,9 @@ func NewService(config ServiceConfig, logger gokitlog.Logger) (*Service, error) 
 	mux := http.NewServeMux()
 
 	mux.Handle("/metrics", promhttp.Handler())
-	mux.Handle("/healthz", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.WriteHeader(http.StatusOK)
-		_, _ = rw.Write([]byte("ok"))
+	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
 	}))
 
 	httpServer := &http.Server{
@@ -61,7 +61,7 @@ func NewService(config ServiceConfig, logger gokitlog.Logger) (*Service, error) 
 	}
 
 	s := &Service{
-		Logger:  logger,
+		logger:  logger,
 		config:  config,
 		server:  httpServer,
 		errChan: make(chan error, 1),
@@ -72,7 +72,7 @@ func NewService(config ServiceConfig, logger gokitlog.Logger) (*Service, error) 
 }
 
 func (s *Service) start(_ context.Context) error {
-	log.Info(s.Logger, "msg", "Starting internal http server", "addr", s.server.Addr)
+	log.Info(s.logger, "msg", "Starting internal http server", "addr", s.server.Addr)
 
 	go func() {
 		err := s.server.ListenAndServe()
@@ -98,9 +98,9 @@ func (s *Service) stop(failureCase error) error {
 	defer cancel()
 
 	if failureCase != nil && !errors.Is(failureCase, context.Canceled) {
-		log.Warn(s.Logger, "msg", "shutting down internal http server due to failure", "failure", failureCase)
+		log.Warn(s.logger, "msg", "shutting down internal http server due to failure", "failure", failureCase)
 	} else {
-		log.Info(s.Logger, "msg", "shutting down internal http server")
+		log.Info(s.logger, "msg", "shutting down internal http server")
 	}
 
 	err := s.server.Shutdown(ctx)

--- a/pkg/internalserver/service.go
+++ b/pkg/internalserver/service.go
@@ -1,0 +1,112 @@
+package internalserver
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"time"
+
+	gokitlog "github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/influx2cortex/pkg/util/log"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	DefaultListenAddress           = "0.0.0.0"
+	DefaultListenPort              = 8081
+	DefaultGracefulShutdownTimeout = 5 * time.Second
+)
+
+type ServiceConfig struct {
+	HTTPListenAddress       string
+	HTTPListenPort          int
+	GracefulShutdownTimeout time.Duration
+}
+
+func (c *ServiceConfig) RegisterFlags(flags *flag.FlagSet) {
+	flags.StringVar(&c.HTTPListenAddress, "internalserver.http-listen-address", DefaultListenAddress, "Sets the listen address for the internal http server")
+	flags.IntVar(&c.HTTPListenPort, "internalserver.http-listen-port", DefaultListenPort, "Sets listen address port for the internal http server")
+	flags.DurationVar(&c.GracefulShutdownTimeout, "internalserver.graceful-shutdown-timeout", DefaultGracefulShutdownTimeout, "Graceful shutdown period; defaults to 5 seconds")
+}
+
+type Service struct {
+	services.Service
+
+	Logger gokitlog.Logger
+
+	config  ServiceConfig
+	server  *http.Server
+	errChan chan error
+}
+
+func NewService(config ServiceConfig, logger gokitlog.Logger) (*Service, error) {
+	if logger == nil {
+		return nil, errors.New("logger should not be nil")
+	}
+
+	mux := http.NewServeMux()
+
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/healthz", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte("ok"))
+	}))
+
+	httpServer := &http.Server{
+		Addr:    fmt.Sprintf("%s:%d", config.HTTPListenAddress, config.HTTPListenPort),
+		Handler: mux,
+	}
+
+	s := &Service{
+		Logger:  logger,
+		config:  config,
+		server:  httpServer,
+		errChan: make(chan error, 1),
+	}
+	s.Service = services.NewBasicService(s.start, s.run, s.stop).WithName("internal")
+
+	return s, nil
+}
+
+func (s *Service) start(_ context.Context) error {
+	log.Info(s.Logger, "msg", "Starting internal http server", "addr", s.server.Addr)
+
+	go func() {
+		err := s.server.ListenAndServe()
+		s.errChan <- err
+	}()
+
+	return nil
+}
+
+func (s *Service) run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-s.errChan:
+			return err
+		}
+	}
+}
+
+func (s *Service) stop(failureCase error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), s.config.GracefulShutdownTimeout)
+	defer cancel()
+
+	if failureCase != nil && !errors.Is(failureCase, context.Canceled) {
+		log.Warn(s.Logger, "msg", "shutting down internal http server due to failure", "failure", failureCase)
+	} else {
+		log.Info(s.Logger, "msg", "shutting down internal http server")
+	}
+
+	err := s.server.Shutdown(ctx)
+	if err != nil {
+		return fmt.Errorf("error during shutdown of internal http server: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,16 +63,16 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, flags *flag.FlagSet) {
 	if prefix != "" && !strings.HasSuffix(prefix, ".") {
 		prefix += "."
 	}
-	flags.StringVar(&cfg.HTTPListenAddress, prefix+"server.http-listen-address", "0.0.0.0", "Sets listen address for the http server.")
-	flags.IntVar(&cfg.HTTPListenPort, prefix+"server.http-listen-port", defaultListenPort, "Sets listen address port for the http server.")
-	flags.IntVar(&cfg.HTTPConnLimit, prefix+"server.http-listen-conn-limit", 0, "Sets a limit to the amount of http connections. Defaults to no limit.")
-	flags.DurationVar(&cfg.ServerGracefulShutdownTimeout, prefix+"server.graceful-shutdown-timeout", defaultServerGracefulShutdown, "Graceful shutdown period. Defaults to 5 seconds.")
-	flags.DurationVar(&cfg.HTTPServerReadTimeout, prefix+"server.http-server-read-timeout", defaultHTTPReadTimeout, "HTTP request read timeout. Defaults to 30 seconds.")
-	flags.DurationVar(&cfg.HTTPServerWriteTimeout, prefix+"server.http-server-write-timeout", defaultHTTPWriteimeout, "HTTP request write timeout. Defaults to 30 seconds.")
-	flags.DurationVar(&cfg.HTTPServerIdleTimeout, prefix+"server.http-server-idle-timeout", defaultHTTPIdleimeout, "HTTP request idle timeout. Defaults to 30 seconds.")
-	flags.Int64Var(&cfg.HTTPMaxRequestSizeLimit, prefix+"server.http-max-req-size-limit", defaultHTTPRequestSizeLimit, "HTTP max request body size limit. Defaults to 10 mb.")
+	flags.StringVar(&cfg.HTTPListenAddress, prefix+"server.http-listen-address", "0.0.0.0", "Sets listen address for the http server")
+	flags.IntVar(&cfg.HTTPListenPort, prefix+"server.http-listen-port", defaultListenPort, "Sets listen address port for the http server")
+	flags.IntVar(&cfg.HTTPConnLimit, prefix+"server.http-listen-conn-limit", 0, "Sets a limit to the amount of http connections, 0 means no limit")
+	flags.DurationVar(&cfg.ServerGracefulShutdownTimeout, prefix+"server.graceful-shutdown-timeout", defaultServerGracefulShutdown, "Graceful shutdown period")
+	flags.DurationVar(&cfg.HTTPServerReadTimeout, prefix+"server.http-server-read-timeout", defaultHTTPReadTimeout, "HTTP request read timeout")
+	flags.DurationVar(&cfg.HTTPServerWriteTimeout, prefix+"server.http-server-write-timeout", defaultHTTPWriteimeout, "HTTP request write timeout")
+	flags.DurationVar(&cfg.HTTPServerIdleTimeout, prefix+"server.http-server-idle-timeout", defaultHTTPIdleimeout, "HTTP request idle timeout")
+	flags.Int64Var(&cfg.HTTPMaxRequestSizeLimit, prefix+"server.http-max-req-size-limit", defaultHTTPRequestSizeLimit, "HTTP max request body size limit in MB")
 	flags.StringVar(&cfg.PathPrefix, prefix+"server.path-prefix", "", "Base path to serve all API routes from (e.g. /v1/)")
-	flags.IntVar(&cfg.GRPCListenPort, prefix+"server.grpc-listen-port", defaultGrpcPort, "Sets listen address port for the http server.")
+	flags.IntVar(&cfg.GRPCListenPort, prefix+"server.grpc-listen-port", defaultGrpcPort, "Sets listen address port for the http server")
 }
 
 // Server initializes an Router webserver as well as the desired middleware configuration


### PR DESCRIPTION
This PR adds an "internal" server that defaults to listening on port 8081 and provides two endpoints:

- `/metrics`: Prometheus metrics endpoint
- `/healthz`: A health check endpoint