### PR TITLE
Add .tag and .tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ cmd/influx2cortex/influx2cortex
 vendor/
 .drone/coverage
 .drone/ghcomment
+.tag
+.tags


### PR DESCRIPTION
The CI/CD pipeline has only been setting `DockerTag` as something like `20220411231345-main-modified` when instead it should be something like `20220412182500-main-5ec54e2`. The tag generated by`scripts/generate-tags.sh` includes `-modified` when it detects changes in HEAD, which was always happening because a previous step in the pipeline always generates `.tag` and `.tags` files.

These are safe to ignore so I'm just adding those files to the `.gitignore` for this project.