### PR TITLE
Update write endpoint

### DIFF
--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -20,6 +20,8 @@ type API struct {
 func (a *API) Register(router *mux.Router) {
 	registerer := route.NewMuxRegisterer(router)
 
+	// Registering two write endpoints; the second is necessary to allow for direct pushes to the proxy
+	registerer.RegisterRoute("/api/v1/push/influx/write", http.HandlerFunc(a.handleSeriesPush), http.MethodPost)
 	registerer.RegisterRoute("/api/v2/write", http.HandlerFunc(a.handleSeriesPush), http.MethodPost)
 }
 

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -20,7 +20,7 @@ type API struct {
 func (a *API) Register(router *mux.Router) {
 	registerer := route.NewMuxRegisterer(router)
 
-	registerer.RegisterRoute("/api/v1/push/influx/write", http.HandlerFunc(a.handleSeriesPush), http.MethodPost)
+	registerer.RegisterRoute("/api/v2/write", http.HandlerFunc(a.handleSeriesPush), http.MethodPost)
 }
 
 func NewAPI(logger log.Logger, client remotewrite.Client, recorder Recorder) (*API, error) {

--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -20,7 +20,7 @@ type API struct {
 func (a *API) Register(router *mux.Router) {
 	registerer := route.NewMuxRegisterer(router)
 
-	// Registering two write endpoints; the second is necessary to allow for direct pushes to the proxy
+	// Registering two write endpoints; the second is necessary to allow for compatibility with clients that hard-code the endpoint
 	registerer.RegisterRoute("/api/v1/push/influx/write", http.HandlerFunc(a.handleSeriesPush), http.MethodPost)
 	registerer.RegisterRoute("/api/v2/write", http.HandlerFunc(a.handleSeriesPush), http.MethodPost)
 }

--- a/pkg/influx/auth_test.go
+++ b/pkg/influx/auth_test.go
@@ -85,7 +85,7 @@ func TestAuthentication(t *testing.T) {
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), service))
 			defer service.StopAsync()
 
-			url := fmt.Sprintf("http://%s/api/v2/write/influx/write", service.Addr())
+			url := fmt.Sprintf("http://%s/api/v2/write", service.Addr())
 			req, err := http.NewRequest("POST", url, bytes.NewReader([]byte("measurement,t1=v1 f1=2 1465839830100400200")))
 			require.NoError(t, err)
 			req = req.WithContext(user.InjectOrgID(req.Context(), tt.orgID))

--- a/pkg/influx/auth_test.go
+++ b/pkg/influx/auth_test.go
@@ -22,7 +22,6 @@ import (
 func TestAuthentication(t *testing.T) {
 	tests := []struct {
 		name          string
-		url           string
 		data          string
 		enableAuth    bool
 		orgID         string
@@ -32,7 +31,6 @@ func TestAuthentication(t *testing.T) {
 	}{
 		{
 			name:          "test auth enabled valid org ID",
-			url:           "/write",
 			data:          "measurement,t1=v1 f1=2 1465839830100400200",
 			enableAuth:    true,
 			orgID:         "valid",
@@ -42,7 +40,6 @@ func TestAuthentication(t *testing.T) {
 		},
 		{
 			name:          "test auth enabled invalid org ID",
-			url:           "/write",
 			data:          "measurement,t1=v1 f1=2 1465839830100400200",
 			enableAuth:    true,
 			orgID:         "",
@@ -52,7 +49,6 @@ func TestAuthentication(t *testing.T) {
 		},
 		{
 			name:          "test auth disabled",
-			url:           "/write",
 			data:          "measurement,t1=v1 f1=2 1465839830100400200",
 			enableAuth:    false,
 			orgID:         "",
@@ -89,7 +85,7 @@ func TestAuthentication(t *testing.T) {
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), service))
 			defer service.StopAsync()
 
-			url := fmt.Sprintf("http://%s/api/v1/push/influx/write", service.Addr())
+			url := fmt.Sprintf("http://%s/api/v2/write/influx/write", service.Addr())
 			req, err := http.NewRequest("POST", url, bytes.NewReader([]byte("measurement,t1=v1 f1=2 1465839830100400200")))
 			require.NoError(t, err)
 			req = req.WithContext(user.InjectOrgID(req.Context(), tt.orgID))


### PR DESCRIPTION
This PR updates the write endpoint that is registered as a route in the proxy. This endpoint needs to be updated in order to allow for applications such as the InfluxDB client API to push directly to the proxy. The expected endpoint for the InfluxDB client is "/api/v2/write". 