### PR TITLE
Make max request size configurable

### DIFF
--- a/pkg/influx/errors_test.go
+++ b/pkg/influx/errors_test.go
@@ -87,7 +87,10 @@ func TestHandleError(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			remoteWriteMock := &remotewritemock.Client{}
-			api, err := NewAPI(log.NewNopLogger(), remoteWriteMock, tt.recorderMock())
+			conf := ProxyConfig{
+				Logger: log.NewNopLogger(),
+			}
+			api, err := NewAPI(conf, remoteWriteMock, tt.recorderMock())
 			require.NoError(t, err)
 
 			api.handleError(recorder, tt.req, tt.err)

--- a/pkg/influx/parser.go
+++ b/pkg/influx/parser.go
@@ -36,11 +36,15 @@ func parseInfluxLineReader(ctx context.Context, r *http.Request, maxSize int) ([
 	reader, err := batchReadCloser(r.Body, encoding, int64(maxSize))
 	if err != nil {
 		return nil, errorx.BadRequest{Msg: "gzip compression error", Err: err}
-
 	}
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, errorx.BadRequest{Msg: "can't read body", Err: err}
+	}
+
+	err = reader.Close()
+	if err != nil {
+		return nil, errorx.BadRequest{Msg: "problem reading body", Err: err}
 	}
 
 	points, err := models.ParsePointsWithPrecision(data, time.Now().UTC(), precision)


### PR DESCRIPTION
This PR makes the maximum request size configurable via the `max.request.size.bytes` command line argument. It defaults to the existing hardcoded value of 100 KB.