### PR TITLE
JSON response body on errors

### DIFF
--- a/pkg/influx/errors.go
+++ b/pkg/influx/errors.go
@@ -55,7 +55,7 @@ func tryUnwrap(err error) error {
 // handleError tries to extract an errorx.Error from the given error, logging
 // and setting the http response code as needed. All non-errorx errors are
 // considered internal errors. Please do not try to fix error categorization in
-// this function. All client errors should be categorized as an `errorx` at the
+// this function. All client errors should be categorized as an errorx at the
 // site where they are thrown.
 func (a *API) handleError(w http.ResponseWriter, r *http.Request, err error, logger log.Logger) {
 	var statusCode int

--- a/pkg/influx/errors.go
+++ b/pkg/influx/errors.go
@@ -2,6 +2,7 @@ package influx
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,6 +16,35 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 )
 
+// Error codes copied from https://github.com/influxdata/influxdb/blob/569e84d4a73250f2928136e5b40452d058a149bd/kit/platform/errors/errors.go#L15-L29
+const (
+	EInternal            = "internal error"
+	ENotImplemented      = "not implemented"
+	ENotFound            = "not found"
+	EConflict            = "conflict"             // action cannot be performed
+	EInvalid             = "invalid"              // validation failed
+	EUnprocessableEntity = "unprocessable entity" // data type is correct, but out of range
+	EEmptyValue          = "empty value"
+	EUnavailable         = "unavailable"
+	EForbidden           = "forbidden"
+	ETooManyRequests     = "too many requests"
+	EUnauthorized        = "unauthorized"
+	EMethodNotAllowed    = "method not allowed"
+	ETooLarge            = "request too large"
+)
+
+func errorxToInfluxErrorCode(err errorx.Error) string {
+	switch {
+	case errors.As(err, &errorx.BadRequest{}):
+		return EInvalid
+	case errors.As(err, &errorx.Internal{}):
+		return EInternal
+	case errors.As(err, &errorx.Conflict{}):
+		return EConflict
+	}
+	return EInternal
+}
+
 func tryUnwrap(err error) error {
 	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
 		return wrapped.Unwrap()
@@ -25,20 +55,23 @@ func tryUnwrap(err error) error {
 // handleError tries to extract an errorx.Error from the given error, logging
 // and setting the http response code as needed. All non-errorx errors are
 // considered internal errors. Please do not try to fix error categorization in
-// this function. All client errors should be categorized as an errorx at the
+// this function. All client errors should be categorized as an `errorx` at the
 // site where they are thrown.
 func (a *API) handleError(w http.ResponseWriter, r *http.Request, err error, logger log.Logger) {
 	var statusCode int
 	var httpErrString string
 	var errx errorx.Error
+	errorCode := EInternal
 	switch {
 	case errors.As(err, &errx):
+		errorCode = errorxToInfluxErrorCode(errx)
 		httpErrString = errx.Message()
 		statusCode = errx.HTTPStatusCode()
 		err = errx
 	case errors.Is(err, context.DeadlineExceeded) || isGRPCTimeout(err):
 		httpErrString = "network timeout"
 		statusCode = http.StatusGatewayTimeout
+		errorCode = EUnavailable
 	case errors.Is(err, context.Canceled):
 		// Note: It seems unlikely this can happen other than as a timeout, so we
 		// should call it an internal error.
@@ -55,6 +88,7 @@ func (a *API) handleError(w http.ResponseWriter, r *http.Request, err error, log
 			}
 			httpErrString = "network timeout"
 			statusCode = http.StatusGatewayTimeout
+			errorCode = EUnavailable
 		}
 	default:
 		httpErrString = "uncategorized error"
@@ -66,7 +100,26 @@ func (a *API) handleError(w http.ResponseWriter, r *http.Request, err error, log
 		_ = level.Warn(logger).Log("msg", httpErrString, "response_code", statusCode, "err", tryUnwrap(err))
 	}
 	a.recorder.measureProxyErrors(fmt.Sprintf("%T", err))
-	http.Error(w, httpErrString, statusCode)
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(statusCode)
+	e := struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}{
+		Code:    errorCode,
+		Message: httpErrString,
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		_ = level.Warn(logger).Log("msg", "failed to marshal error response", "err", err)
+		return
+	}
+	_, err = w.Write(b)
+	if err != nil {
+		_ = level.Warn(logger).Log("msg", "failed to write error response", "err", err)
+		return
+	}
 }
 
 func isNetworkTimeout(err error) bool {

--- a/pkg/influx/errors_test.go
+++ b/pkg/influx/errors_test.go
@@ -99,6 +99,36 @@ func TestHandleError(t *testing.T) {
 	}
 }
 
+func TestErrorxToInfluxErrorCode(t *testing.T) {
+	tests := map[string]struct {
+		err        errorx.Error
+		expectCode string
+	}{
+		"bad request": {
+			err:        errorx.BadRequest{},
+			expectCode: EInvalid,
+		},
+		"conflict": {
+			err:        errorx.Conflict{},
+			expectCode: EConflict,
+		},
+		"internal": {
+			err:        errorx.Internal{},
+			expectCode: EInternal,
+		},
+		"non-mapped error defaults to internal": {
+			err:        errorx.RateLimited{},
+			expectCode: EInternal,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.expectCode, errorxToInfluxErrorCode(tt.err))
+		})
+	}
+}
+
 // Mock of Golang's internal poll.TimeoutError
 type mockNetworkError struct{}
 


### PR DESCRIPTION
Should close https://github.com/grafana/influx2cortex/issues/79.


Useful links:

- v2 docs: https://docs.influxdata.com/influxdb/v2.6/api/#operation/PostWrite
- Piece of code in influxdb that writes the JSON on errors: https://github.com/influxdata/influxdb/blob/569e84d4a73250f2928136e5b40452d058a149bd/kit/transport/http/error_handler.go#L48-L61

_____________________________

## Solution

We know we want to write a JSON on errrors, the question is what JSON exactly. The current code in influxdb doesn't exactly match the v2 docs, but here's 2 observations from looking at the description of a 500 response:

![image](https://user-images.githubusercontent.com/32206519/222291400-5700bc4c-924e-4e15-9a41-c0e8328a4163.png)


1. `"code"` is an enum, and there are guarantees about what it is
2. `"code"` is the only mandatory field, along with `"message"` for 413. So (at least for v2) it should be fine to do what influxdb is doing and only write those two.

With that in mind, I decided to make the response a JSON with those two fields, and reference the enums for `"code"`.


## Extra notes

- Note that a successful write is a 204, which doesn't have a body. So it makes sense to only do this in the error handling path.
- This current solution follows v2. But [v1 docs](https://docs.influxdata.com/influxdb/v1.8/tools/api/#examples-7) are slightly different. The JSON body seems to only have an `"error"` field, which might be what Telegraf currently expects: https://github.com/influxdata/telegraf/blob/f87916aaa96368ca6d8a2de3e38a513785a1ee99/plugins/outputs/influxdb/http.go#L366 . Still didn't dig into this but still wanted to open the PR; we might want to have different logic for v1 and v2 (currently we don't. We could do that in this PR or a separate one after this.

