### PR TITLE
Enable dropping old samples

### DIFF
--- a/pkg/influx/mock_recorder_test.go
+++ b/pkg/influx/mock_recorder_test.go
@@ -32,6 +32,11 @@ func (_m *MockRecorder) measureConversionDuration(duration time.Duration) {
 	_m.Called(duration)
 }
 
+// measureMetricsDropped provides a mock function with given fields: count
+func (_m *MockRecorder) measureMetricsDropped(count int) {
+	_m.Called(count)
+}
+
 // measureMetricsParsed provides a mock function with given fields: count
 func (_m *MockRecorder) measureMetricsParsed(count int) {
 	_m.Called(count)

--- a/pkg/influx/proxy.go
+++ b/pkg/influx/proxy.go
@@ -40,6 +40,9 @@ type ProxyConfig struct {
 	Registerer prometheus.Registerer
 	// MaxRequestSizeBytes limits the size of an incoming request. Any value less than or equal to 0 means no limit.
 	MaxRequestSizeBytes int
+	// MaxSampleAgeSeconds is used to drop samples with a timestamp older than the current
+	// time - MaxSampleAgeSeconds. Any value less than or equal to 0 means no limit.
+	MaxSampleAgeSeconds int64
 }
 
 func (c *ProxyConfig) RegisterFlags(flags *flag.FlagSet) {
@@ -48,6 +51,7 @@ func (c *ProxyConfig) RegisterFlags(flags *flag.FlagSet) {
 
 	flags.BoolVar(&c.EnableAuth, "auth.enable", true, "require X-Scope-OrgId header")
 	flags.IntVar(&c.MaxRequestSizeBytes, "max.request.size.bytes", DefaultMaxRequestSizeBytes, "limit the size of incoming batches; 0 for no limit")
+	flags.Int64Var(&c.MaxSampleAgeSeconds, "max.sample.age.seconds", 0, "max age of samples in seconds; 0 for no limit")
 }
 
 // ProxyService is the actual Influx Proxy dskit service.

--- a/pkg/influx/recorder_test.go
+++ b/pkg/influx/recorder_test.go
@@ -35,6 +35,19 @@ func TestRecorder(t *testing.T) {
 influxdb_proxy_ingester_metrics_parsed_total 3
 `,
 		},
+		"Measure dropped samples": {
+			measure: func(r Recorder) {
+				r.measureMetricsDropped(1)
+			},
+			expMetricNames: []string{
+				"influxdb_proxy_ingester_metrics_dropped_total",
+			},
+			expMetrics: `
+# HELP influxdb_proxy_ingester_metrics_dropped_total The total number of metrics that have been dropped.
+# TYPE influxdb_proxy_ingester_metrics_dropped_total counter
+influxdb_proxy_ingester_metrics_dropped_total 1
+`,
+		},
 		"Measure rejected samples": {
 			measure: func(r Recorder) {
 				r.measureProxyErrors("reason")


### PR DESCRIPTION
This PR adds the flag `-max.sample.age.seconds` that is used to drop metrics with a timestamp older than the current time - `max.sample.age.seconds`.

We are using influx2cortex to send metrics collected by Telegraf agents to a Mimir cluster. Unfortunately, our services that send metrics to Telegraf don't send them in a predictable manner. Some metrics get delayed for multiple minutes, and when these are written to Mimir they trigger the out of order error. influx2cortex returns the error to Telegraf, and instead of dropping the metrics Telegraf will resend them at a later period. This will never succeed, and it makes Telegraf unable to send any metrics to Mimir at all. The only way to resolve it is to restart the Telegraf agent to clear its buffer.

With this solution, metrics that are older than the configured age will be dropped by influx2cortex instead of being written to Mimir. This will not trigger the out of order error, and a success will be returned to Telegraf. influx2cortex will record the count of dropped metrics as an internal metric and also log them.

There is a way to drop the metrics from Telegraf's side through the [execd processor plugin](https://github.com/influxdata/telegraf/tree/master/plugins/processors/execd), but in our architecture we would need to implement it in all hosts, while in this way we only need to apply it in one place. This also has the advantage of having logs and metrics available from one location, while in the other they would have to be collected from all hosts.

We are also aware that this is a solution to a special case. Having old metrics is not necessarily wrong, and they won't necessarily trigger the out of order error. A service may only send metrics very infrequently, e.g., every hour, but as long as they are in order they should still be accepted by Mimir. In our case though the timeliness of the metrics is more important, so we are ok with dropping old metrics. We are making this PR in case other teams may find it useful.

Thank you.