### PR TITLE
Bump DefaultMaxRequestSizeBytes to 10MB

### DIFF
--- a/pkg/influx/proxy.go
+++ b/pkg/influx/proxy.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	DefaultMaxRequestSizeBytes = 100 << 10 // 100 KB
+	// Upped to 10MB based on empirical evidence of proxy receiving batches from telegraf agent
+	DefaultMaxRequestSizeBytes = 10 << 20 // 10 MB
 )
 
 // ProxyConfig holds objects needed to start running an influx2cortex proxy


### PR DESCRIPTION
For: https://github.com/grafana/influx2cortex/issues/75

Based on evidence gathered with https://github.com/grafana/influx2cortex/pull/81 logging enabled and running proxy for extended period with wide variation in inputs.

Largest batches from `telegraf` agent were somewhere just over 1MB, so setting it to 10MB to give enough leeway.