### PR TITLE
build: fix local build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/influx2cortex
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/ahmetalpbalkan/dlog v0.0.0-20170105205344-4fb5f8204f26

--- a/scripts/compile_commands.sh
+++ b/scripts/compile_commands.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Builds command binaries
+set -eufo pipefail
+export SHELLOPTS	# propagate set to children by default
+IFS=$'\t\n'
+
+command -v go >/dev/null 2>&1 || { echo 'Please install go'; exit 1; }
+
+export GOPRIVATE=""
+export CGO_ENABLED=0
+export GOOS=linux
+export GOARCH=amd64
+GIT_COMMIT="${DRONE_COMMIT:-$(git rev-list -1 HEAD)}"
+COMMIT_UNIX_TIMESTAMP="$(git --no-pager show -s --format=%ct "${GIT_COMMIT}")"
+# DOCKER_TAG="$(bash scripts/docker-tag.sh)"
+DOCKER_TAG="TODO"
+
+# shellcheck disable=SC2043
+for cmd in influx2cortex
+do
+    go build \
+    -o "dist/${cmd}" \
+    -ldflags "\
+        -w \
+        -X 'github.com/grafana/mimir-proxies/pkg/appcommon.CommitUnixTimestamp=${COMMIT_UNIX_TIMESTAMP}' \
+        -X 'github.com/grafana/mimir-proxies/pkg/appcommon.DockerTag=${DOCKER_TAG}' \
+        " \
+    "github.com/grafana/influx2cortex/cmd/${cmd}"
+
+    echo "Succesfully built ${cmd} into dist/${cmd}"
+done


### PR DESCRIPTION
#160 removed the script triggered by `make build` which is for local building, adding it back.

Also tweaked go version from `1.23` to `1.23.0` to avoid go toolchain errors.