### PR TITLE
build: use distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine as build
+FROM golang:1.23-alpine AS build
 RUN apk add --update --no-cache git coreutils
 
 WORKDIR /go/src/github.com/grafana/influx2cortex

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN addgroup -g 1000 app && \
 
 FROM gcr.io/distroless/static-debian12
 
-COPY --from=groupbuilder /etc/passwd /etc/passwd
-COPY --from=groupbuilder /etc/group /etc/group
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
 
 WORKDIR /app
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,15 @@ RUN GIT_COMMIT="${DRONE_COMMIT:-${GITHUB_SHA:-$(git rev-list -1 HEAD)}}"; \
     " \
     github.com/grafana/influx2cortex/cmd/influx2cortex
 
-FROM alpine:3.20
 
-RUN apk add --update --no-cache ca-certificates
 RUN addgroup -g 1000 app && \
   adduser -u 1000 -h /app -G app -S app
+
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=groupbuilder /etc/passwd /etc/passwd
+COPY --from=groupbuilder /etc/group /etc/group
+
 WORKDIR /app
 USER app
 


### PR DESCRIPTION
Using distroless images will reduce our exposure to CVEs.