### PR TITLE
chore: add tests to defend against influx parser changes

### DIFF
--- a/pkg/influx/parser.go
+++ b/pkg/influx/parser.go
@@ -146,16 +146,16 @@ func influxPointToTimeseries(pt models.Point) ([]mimirpb.TimeSeries, error) {
 func replaceInvalidChars(in *string) {
 	for charIndex, char := range *in {
 		charInt := int(char)
-		if !((charInt >= 97 && charInt <= 122) || // a-z
-			(charInt >= 65 && charInt <= 90) || // A-Z
-			(charInt >= 48 && charInt <= 57) || // 0-9
-			charInt == 95) { // _
+		if !((charInt >= 'a' && charInt <= 'z') || // a-z
+			(charInt >= 'A' && charInt <= 'Z') || // A-Z
+			(charInt >= '0' && charInt <= '9') || // 0-9
+			charInt == '_') { // _
 
 			*in = (*in)[:charIndex] + "_" + (*in)[charIndex+1:]
 		}
 	}
 	// prefix with _ if first char is 0-9
-	if len(*in) > 0 && int((*in)[0]) >= 48 && int((*in)[0]) <= 57 {
+	if len(*in) > 0 && int((*in)[0]) >= '0' && int((*in)[0]) <= '9' {
 		*in = "_" + *in
 	}
 }

--- a/pkg/influx/parser.go
+++ b/pkg/influx/parser.go
@@ -155,7 +155,7 @@ func replaceInvalidChars(in *string) {
 		}
 	}
 	// prefix with _ if first char is 0-9
-	if int((*in)[0]) >= 48 && int((*in)[0]) <= 57 {
+	if len(*in) > 0 && int((*in)[0]) >= 48 && int((*in)[0]) <= 57 {
 		*in = "_" + *in
 	}
 }

--- a/pkg/influx/parser_test.go
+++ b/pkg/influx/parser_test.go
@@ -159,6 +159,16 @@ func TestInvalidInput(t *testing.T) {
 			data:      "measurement,t1=v1 1465839830100400200", // missing field
 			errorType: &errorx.BadRequest{},
 		},
+		{
+			name: "parse missing tag name",
+			url:  "/write",
+			data: "measurement,=v1 1465839830100400200", // missing tag name
+		},
+		{
+			name: "parse missing tag value",
+			url:  "/write",
+			data: "measurement,t1= 1465839830100400200", // missing tag value
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/influx/parser_test.go
+++ b/pkg/influx/parser_test.go
@@ -159,16 +159,6 @@ func TestInvalidInput(t *testing.T) {
 			data:      "measurement,t1=v1 1465839830100400200", // missing field
 			errorType: &errorx.BadRequest{},
 		},
-		{
-			name: "parse missing tag name",
-			url:  "/write",
-			data: "measurement,=v1 1465839830100400200", // missing tag name
-		},
-		{
-			name: "parse missing tag value",
-			url:  "/write",
-			data: "measurement,t1= 1465839830100400200", // missing tag value
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`replaceInvalidChars()` shouldn't be called with an empty string but we can't guarantee that as it is called on the result(s) of an influx library call.

Add some defensive code just in case this assumption ever changes.