### PR TITLE
feat: add health check with /heatlhz endpoint

### DIFF
--- a/pkg/influx/api.go
+++ b/pkg/influx/api.go
@@ -29,6 +29,7 @@ func (a *API) Register(router *mux.Router) {
 	// Registering two write endpoints; the second is necessary to allow for compatibility with clients that hard-code the endpoint
 	registerer.RegisterRoute("/api/v1/push/influx/write", http.HandlerFunc(a.handleSeriesPush), http.MethodPost)
 	registerer.RegisterRoute("/api/v2/write", http.HandlerFunc(a.handleSeriesPush), http.MethodPost)
+	registerer.RegisterRoute("/healthz", http.HandlerFunc(a.handleHealth), http.MethodGet)
 }
 
 func NewAPI(conf ProxyConfig, client remotewrite.Client, recorder Recorder) (*API, error) {
@@ -38,6 +39,11 @@ func NewAPI(conf ProxyConfig, client remotewrite.Client, recorder Recorder) (*AP
 		recorder:            recorder,
 		maxRequestSizeBytes: conf.MaxRequestSizeBytes,
 	}, nil
+}
+
+func (a *API) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("OK"))
+	w.WriteHeader(http.StatusOK)
 }
 
 // HandlerForInfluxLine is a http.Handler which accepts Influx Line protocol and converts it to WriteRequests.

--- a/pkg/influx/api_test.go
+++ b/pkg/influx/api_test.go
@@ -219,3 +219,17 @@ func TestHandleSeriesPush(t *testing.T) {
 		})
 	}
 }
+func TestHandleHealth(t *testing.T) {
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	req.Header.Set("X-Scope-OrgID", "fake")
+	rec := httptest.NewRecorder()
+	logger := log.NewNopLogger()
+	api := &API{
+		logger: logger,
+	}
+
+	api.handleHealth(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "OK", rec.Body.String())
+}


### PR DESCRIPTION
This PR adds the `/healthz` endpoint, which always returns `OK`. Currently, it is not possible to monitor the influx2cortex program without making sure that the metrics endpoint is reachable. With this PR, it is possible to check the health without having to rely on the metrics server.