### PR TITLE
ci: comment test coverage in a separate job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,6 +73,7 @@ jobs:
           path: coverage.out
   comment-coverage:
     runs-on: ubuntu-latest
+    needs: test
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -66,15 +66,27 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Run Tests
         run: go test -coverprofile coverage.out ./...
+      - name: Save Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.out
+  comment-coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download Coverage Report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
       - name: Generate Coverage Summary
         run: go run ci/cmd/coverage/main.go -f coverage.out > comment.txt
       - name: Comment Coverage Summary
         # This will update the comment in place on successive runs
         uses: mshick/add-pr-comment@v2
         with:
-          message-path: comment.txt
-      
-    
+          message-path: comment.txt   
   acceptance:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,6 +77,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Download Coverage Report
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This lets us make this job optional in case it fails.

One case where it can fail is if the PR comes from a fork, where permissions are missing.