### PR TITLE
fix(test): fix influx parser tests

### DIFF
--- a/pkg/influx/parser_test.go
+++ b/pkg/influx/parser_test.go
@@ -177,6 +177,21 @@ func TestParseInfluxLineReader(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "parse invalid char conversion number prefix",
+			url:  "/",
+			data: "0measurement,1t1=v1 f1=0 1465839830100400200",
+			expectedResult: []mimirpb.TimeSeries{
+				{
+					Labels: []mimirpb.LabelAdapter{
+						{Name: "_1t1", Value: "v1"},
+						{Name: "__name__", Value: "_0measurement_f1"},
+						{Name: "__proxy_source__", Value: "influx"},
+					},
+					Samples: []mimirpb.Sample{{Value: 0, TimestampMs: 1465839830100}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/influx/parser_test.go
+++ b/pkg/influx/parser_test.go
@@ -23,6 +23,21 @@ func TestParseInfluxLineReader(t *testing.T) {
 		expectedResult []mimirpb.TimeSeries
 	}{
 		{
+			name: "parse simple line single value called value",
+			url:  "/",
+			data: "measurement,t1=v1 value=1.5 1465839830100400200",
+			expectedResult: []mimirpb.TimeSeries{
+				{
+					Labels: []mimirpb.LabelAdapter{
+						{Name: "__name__", Value: "measurement"},
+						{Name: "__proxy_source__", Value: "influx"},
+						{Name: "t1", Value: "v1"},
+					},
+					Samples: []mimirpb.Sample{{Value: 1.5, TimestampMs: 1465839830100}},
+				},
+			},
+		},
+		{
 			name: "parse simple line single value",
 			url:  "/",
 			data: "measurement,t1=v1 f1=2 1465839830100400200",


### PR DESCRIPTION
Various fixes to the parser tests:
* Ensure we are getting the right number of results
* Compare all of the results (previous code skipped checking the first expected result each time)
* Added more tests for greater coverage (floats, specified integers such as `82i`)
* Don't expect a metric if the field value is a string.