### PR TITLE
ci: fix build to push from `main`

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -26,7 +26,7 @@ jobs:
         uses: grafana/shared-workflows/actions/push-to-gar-docker@main
         with:
           # Don't push from forks
-          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.ref_name == 'main' || github.event.pull_request.head.repo.full_name == github.repository }}
           # If we are building main, push to prod and add the 'latest' tag.
           tags: |-
             ${{ env.DOCKER_TAG }}


### PR DESCRIPTION
We are currently not building `main` pushes, which is wrong.