### PR TITLE
Bump go version to 1.24.4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24.4"
 
 permissions: {}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.24.4-alpine AS build
 RUN apk add --update --no-cache git coreutils
 
 WORKDIR /go/src/github.com/grafana/influx2cortex

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/influx2cortex
 
-go 1.24.1
+go 1.24.4
 
 require (
 	github.com/ahmetalpbalkan/dlog v0.0.0-20170105205344-4fb5f8204f26


### PR DESCRIPTION
Addresses [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2). 